### PR TITLE
required version for boto; calls claude instead of titan.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 langchain
 faiss-cpu
-boto3
-botocore
+boto3 >= 1.34.10
+botocore >= 1.34.10

--- a/tools.py
+++ b/tools.py
@@ -93,7 +93,7 @@ def aws_well_arch_tool(query):
     Question: {query}
     Answer:"""
 
-    generated_text = call_titan(prompt)
+    generated_text = call_claude(prompt)
     print(generated_text)
 
     resp_string = (


### PR DESCRIPTION
*Description of changes:*

* Updated requirements.txt to pull required version of boto3 and botocore.  Versions prior to this don't support the bedrock-runtime client.
* Updated tools.py to call the Claude instead of Titan in case Titan is not enabled in the account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
