### PR TITLE
Fixing deprecation messages: Importing embeddings from langchain is deprecated

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -2,10 +2,10 @@ import xml.etree.ElementTree as ET
 
 import boto3
 import requests
-from langchain.document_loaders import SeleniumURLLoader
-from langchain.embeddings import BedrockEmbeddings
-from langchain.text_splitter import RecursiveCharacterTextSplitter
-from langchain.vectorstores import FAISS
+from langchain_community.document_loaders import SeleniumURLLoader
+from langchain_community.embeddings import BedrockEmbeddings
+from langchain_community.text_splitter import RecursiveCharacterTextSplitter
+from langchain_community.vectorstores import FAISS
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.chrome.service import Service

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 langchain
+langchain-community
 faiss-cpu
 boto3
 botocore

--- a/tools.py
+++ b/tools.py
@@ -1,8 +1,8 @@
 import json
 
 import boto3
-from langchain.embeddings import BedrockEmbeddings
-from langchain.vectorstores import FAISS
+from langchain_community.embeddings import BedrockEmbeddings
+from langchain_community.vectorstores import FAISS
 
 
 bedrock_runtime = boto3.client(


### PR DESCRIPTION
…eprecated. Importing from langchain will no longer be supported

*Issue #, if available: test_tools.py results in deprecation messages.

*Description of changes:* Current use of langchain in ingest.py, tools.py results in deprecation messages thrown. 
I've updated as suggested and tested - code is working.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
